### PR TITLE
Fix docker push with --all-tags

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -19,4 +19,4 @@ cp.execSync(`docker images ${NAME} --format="{{ .Tag }}"`);
 cp.execSync(`docker images ${REGISTRY}/${NAME} --format="{{ .Tag }}"`);
 
 console.log("Pushing...");
-cp.execSync(`docker push ${REGISTRY}/${NAME}`);
+cp.execSync(`docker push --all-tags ${REGISTRY}/${NAME}`);


### PR DESCRIPTION
This PR will fix the docker push. A new docker version does not automatically push all tags by default.